### PR TITLE
fix (db): use correct datetime when initializing Presents

### DIFF
--- a/santabot/cogs/give.py
+++ b/santabot/cogs/give.py
@@ -70,6 +70,8 @@ class Give(commands.Cog):
                     '```'.format(e)
                 )
                 raise e
+            else:
+                self.bot.db.commit()
 
     # -------------------------------------------------------------------------
     # Discord.py `please` prefix for `give` command
@@ -116,6 +118,8 @@ class Give(commands.Cog):
                     '```'.format(e)
                 )
                 raise e
+            else:
+                self.bot.db.commit()
 
     # -------------------------------------------------------------------------
     # Discord.py `gimme` command, equivalent to `give me`
@@ -147,6 +151,8 @@ class Give(commands.Cog):
                     '```'.format(e)
                 )
                 raise e
+            else:
+                self.bot.db.commit()
 
     # -------------------------------------------------------------------------
     # __do_gifting() handles the majority of the gift sending logic

--- a/santabot/db/models/present.py
+++ b/santabot/db/models/present.py
@@ -13,8 +13,19 @@ class Present(db.Entity):
     gifter = orm.Optional(User)
     stolen = orm.Required(bool, default=False)
     please = orm.Required(bool, default=False)
-    date_received = orm.Required(datetime, default=datetime.now(), precision=6)
+    date_received = orm.Required(
+        datetime,
+        default=datetime(
+            year=1995, month=4, day=19, hour=9, minute=2
+        ),
+        precision=6
+    )
     date_stolen = orm.Optional(datetime)
+
+    @orm.db_session
+    def __init__(self, *args, **kwargs):
+        kwargs['date_received'] = datetime.now()
+        super().__init__(*args, **kwargs)
 
     @orm.db_session
     def steal(self, timestamp=None) -> bool:


### PR DESCRIPTION
<!--
    Hello! Thank you for opening a PR for our repo. Please fill out the
    sections below, making sure to follow the instructions you see in these
    comment blocks.

    NB: Your PR needs to pass all CI checks to be accepted.
-->

## Description of your PR

Sets `date_received` on `__init__` instead of class creation


## Affected Components

This PR adds functionality to, modifies the functionality of, or fixes an issue
with:

<!-- Please check any/all that apply by replacing [ ] with [x] -->

  - [x] The Discord Bot
  - [x] The Database or API
  - [ ] Other program functionality (`.env`, scripts, etc.)
  - [ ] Documentation
  - [ ] Containerization
  - [ ] CI
  - [ ] Other: <!-- Please add a description here if this box is checked -->


## New/Additional Dependencies

  - [x] My PR **does not** add any dependencies to `requirements.txt`

<!-- If your PR _does_ add dependencies, please explain why here -->
